### PR TITLE
Create target subdirs if they don't exist

### DIFF
--- a/oaiharvest/harvest.py
+++ b/oaiharvest/harvest.py
@@ -119,11 +119,11 @@ class DirectoryOAIHarvester(OAIHarvester):
                                "{0}.{1}.xml".format(header.identifier(),
                                                     metadataPrefix)
                                )
-            if not os.path.exists(self._dir):
+            if not os.path.isdir(os.path.dirname(fp)):
                 logger.debug("Creating target directory {0}"
                              "".format(self._dir)
                              )
-                os.makedirs(self._dir)
+                os.makedirs(os.path.dirname(fp))
             if not header.isDeleted():
                 logger.debug('Writing to file {0}'.format(fp))
                 with open(fp, 'w') as fh:


### PR DESCRIPTION
I tried to harvest the arXiv metadata, but it failed because it was trying to open a file in a subdirectory that did not exist.

This changes the directory creation behaviour to _mkdir -p_ all dirs in _os.path.dirname(fp)_.

Additionally, it partially works around the problem that the user might use an existing file as _-d_ argument or a target dir might already exist as file (now _os.path.isdir()_ is used instead of _os.path.exists()_ is used).
