### PR TITLE
Allow providers to start with https://

### DIFF
--- a/oaiharvest/harvest.py
+++ b/oaiharvest/harvest.py
@@ -210,7 +210,7 @@ def main(argv=None):
                           in cxn.execute('SELECT name FROM providers')
                           ])
     for provider in providers:
-        if not provider.startswith('http://') and not provider.startswith('https://'):
+        if not provider.startswith(('http://', 'https://')):
             # Fetch details from provider registry
             cursor = cxn.execute('SELECT url, '
                                  'destination, '

--- a/oaiharvest/harvest.py
+++ b/oaiharvest/harvest.py
@@ -210,7 +210,7 @@ def main(argv=None):
                           in cxn.execute('SELECT name FROM providers')
                           ])
     for provider in providers:
-        if not provider.startswith('http://'):
+        if not provider.startswith('http://') and not provider.startswith('https://'):
             # Fetch details from provider registry
             cursor = cxn.execute('SELECT url, '
                                  'destination, '


### PR DESCRIPTION
Currently `oai-harvest` tries to lookup providers like `https://export.arxiv.org/oai2` in the registry instead of recognizing them as a URL.

This PR adds `https://` as an allowed prefixed (in addition to `http://` which is currently the only allowed prefix)