### PR TITLE
Print traceback in case of an exception

### DIFF
--- a/oaiharvest/harvest.py
+++ b/oaiharvest/harvest.py
@@ -48,6 +48,7 @@ import logging
 import os
 import platform
 import sys
+import traceback
 import six
 import six.moves.urllib.parse as urllib
 
@@ -303,6 +304,8 @@ def main(argv=None):
         except Exception as e:
             # Log error
             logger.error(str(e))
+            # Print traceback
+            traceback.print_exc(*sys.exc_info())
             # Continue to next provide without updating database lastHarvest
             continue
 

--- a/oaiharvest/harvest.py
+++ b/oaiharvest/harvest.py
@@ -48,7 +48,6 @@ import logging
 import os
 import platform
 import sys
-import traceback
 import six
 
 from argparse import ArgumentParser
@@ -308,9 +307,7 @@ def main(argv=None):
                          )
         except Exception as e:
             # Log error
-            logger.error(str(e))
-            # Print traceback
-            traceback.print_exc(*sys.exc_info())
+            logger.error(str(e), exc_info=True)
             # Continue to next provide without updating database lastHarvest
             continue
 


### PR DESCRIPTION
I don't know if you want to merge this, but I though I'll at least give you the choice ;-)

Currently, oai-harvest handles exceptions by logging only the exception name. This means it is often hard to debug. This PR adds a traceback print to the `except` clause.

Please let me know what you think. Maybe traceback should be enabled by a `--debug` CLI flag !?!?