### PR TITLE
Fix pyoai returning an escaped metadata string enclosed in b'...'

### DIFF
--- a/oaiharvest/harvest.py
+++ b/oaiharvest/harvest.py
@@ -91,9 +91,10 @@ class OAIHarvester(object):
         # Check server timestamp granularity support
         client.updateGranularity()
         for record in client.listRecords(**kwargs):
+            # Unit test hotfix
             header, metadata, about = record
             # Fix pyoai returning a "b'...'" string for py3k
-            if metadata.startswith("b'"):
+            if isinstance(metadata, str) and metadata.startswith("b'"):
                 metadata = ast.literal_eval(metadata).decode("utf-8")
             yield (header, metadata, about)
 

--- a/oaiharvest/harvest.py
+++ b/oaiharvest/harvest.py
@@ -49,6 +49,7 @@ import os
 import platform
 import sys
 import six
+import ast
 
 from argparse import ArgumentParser
 from datetime import datetime
@@ -90,7 +91,11 @@ class OAIHarvester(object):
         # Check server timestamp granularity support
         client.updateGranularity()
         for record in client.listRecords(**kwargs):
-            yield record
+            header, metadata, about = record
+            # Fix pyoai returning a "b'...'" string for py3k
+            if metadata.startswith("b'"):
+                metadata = ast.literal_eval(metadata).decode("utf-8")
+            yield (header, metadata, about)
 
     def harvest(self, baseUrl, metadataPrefix, **kwargs):
         "Harvest records"

--- a/oaiharvest/test/test_harvest.py
+++ b/oaiharvest/test/test_harvest.py
@@ -66,7 +66,7 @@ class DirectoryOAIHarvesterrTestCase(unittest.TestCase):
     @patch('oaiharvest.harvest.Client')
     def test_listRecords(self, MockClient):
         client = MockClient.return_value
-        mock_recs = [Mock()]
+        mock_recs = [(Mock(), Mock(), Mock)]
         client.listRecords.return_value = iter(mock_recs)
         url = 'https://oai.example.com'
 


### PR DESCRIPTION
In my previous tests I missed that all XML results from Python3 were enclosed in
```
b'...'
```
This seems to be a bug in pyoai, but due to its rather complicated and mostly undocumented sourcecode, I haven't been able to find it yet.

As pyoai has multiple unmerged PRs and you are very quick in merging them, I think it's best to hotfix this issue here until a solution has been found in pyoai.

I used `ast.literal_eval` instead of `eval` to avoid potential security issues.