### PR TITLE
https://github.com/bloomonkey/oai-harvest/issues/33

### DIFF
--- a/oaiharvest/metadata.py
+++ b/oaiharvest/metadata.py
@@ -50,6 +50,7 @@ class XMLMetadataReader(object):
           [six.text_type(
               tostring(rec_element,
                     method="xml",
+                    encoding="unicode",
                     pretty_print=True))
            for rec_element
            in metadata_element])


### PR DESCRIPTION
May also be issue #32 
Save metadata as unicode. 
Use encoding="unicode" , not encoding="utf-8" as the former works both in python 2.x and 3.x 
See: https://lxml.de/api/lxml.etree-module.html#tostring